### PR TITLE
Remove struct array expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -451,17 +451,7 @@ module.exports = grammar({
       ))
     },
 
-    struct_expression: $ => choice(
-      $.struct_array_expression,
-      $.struct_brace_expression,
-    ),
-
-    struct_array_expression: $ => seq(
-      seq($.qualified_type_identifier, $.colon_colon),
-      $.array_expression,
-    ),
-
-    struct_brace_expression: $ => seq(
+    struct_expression: $ => seq(
       optional(seq($.qualified_type_identifier, $.colon_colon)),
       choice(
         seq('{', optional($.struct_field_expressions), '}'),

--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -3,7 +3,7 @@
   (loop_expression)
   (match_expression)
   (nonempty_block_expression)
-  (struct_brace_expression)
+  (struct_expression)
   (structure_item)
 ] @indent.begin
 

--- a/test/corpus/expression.txt
+++ b/test/corpus/expression.txt
@@ -343,27 +343,26 @@ fn init() { let a = A::{ ..id, name: "John Doe" } }
             (expression
               (simple_expression
                 (struct_expression
-                  (struct_brace_expression
-                    (qualified_type_identifier
-                      (identifier
-                        (uppercase_identifier)))
-                    (colon_colon)
-                    (dot_dot)
-                    (expression
-                      (simple_expression
-                        (qualified_identifier
-                          (lowercase_identifier))))
-                    (struct_field_expressions
-                      (labeled_expression
-                        (lowercase_identifier)
-                        (colon)
-                        (expression
-                          (simple_expression
-                            (atomic_expression
-                              (literal
-                                (string_literal
-                                  (string_fragment
-                                    (unescaped_string_fragment)))))))))))))))))))
+                  (qualified_type_identifier
+                    (identifier
+                      (uppercase_identifier)))
+                  (colon_colon)
+                  (dot_dot)
+                  (expression
+                    (simple_expression
+                      (qualified_identifier
+                        (lowercase_identifier))))
+                  (struct_field_expressions
+                    (labeled_expression
+                      (lowercase_identifier)
+                      (colon)
+                      (expression
+                        (simple_expression
+                          (atomic_expression
+                            (literal
+                              (string_literal
+                                (string_fragment
+                                  (unescaped_string_fragment))))))))))))))))))
 
 ================================================================================
 binary expression

--- a/test/corpus/expression.txt
+++ b/test/corpus/expression.txt
@@ -366,49 +366,6 @@ fn init() { let a = A::{ ..id, name: "John Doe" } }
                                     (unescaped_string_fragment)))))))))))))))))))
 
 ================================================================================
-struct construction from array
-================================================================================
-fn init() { let a = A::[1, 2, 3] }
---------------------------------------------------------------------------------
-
-(structure
-  (structure_item
-    (function_definition
-      (function_identifier
-        (lowercase_identifier))
-      (parameters)
-      (block_expression
-        (statement_expression
-          (let_expression
-            (pattern
-              (simple_pattern
-                (lowercase_identifier)))
-            (expression
-              (simple_expression
-                (struct_expression
-                  (struct_array_expression
-                    (qualified_type_identifier
-                      (identifier
-                        (uppercase_identifier)))
-                    (colon_colon)
-                    (array_expression
-                      (expression
-                        (simple_expression
-                          (atomic_expression
-                            (literal
-                              (integer_literal)))))
-                      (expression
-                        (simple_expression
-                          (atomic_expression
-                            (literal
-                              (integer_literal)))))
-                      (expression
-                        (simple_expression
-                          (atomic_expression
-                            (literal
-                              (integer_literal))))))))))))))))
-
-================================================================================
 binary expression
 ================================================================================
 fn main {


### PR DESCRIPTION
`T::[]` has been deprecated and removed in MoonBit.