### PR TITLE
fix(queries/textobjects): fix `@(function|block).inner` when a block starts with `for`

### DIFF
--- a/queries/textobjects.scm
+++ b/queries/textobjects.scm
@@ -46,6 +46,12 @@
   ","? @_end)
   (#make-range! "parameter.outer" @parameter.inner @_end))
 
+((array_expression
+  (expression) @parameter.inner
+  .
+  ","? @_end)
+  (#make-range! "parameter.outer" @parameter.inner @_end))
+
 ((string_interpolation
   (interpolator (expression) @parameter.inner)
   @parameter.outer))

--- a/queries/textobjects.scm
+++ b/queries/textobjects.scm
@@ -58,7 +58,9 @@
 
 ; block
 
-((block_expression (_) @block.inner) @block.outer)
+(((nonempty_block_expression) @block.inner
+   (#offset! @block.inner 0 1 0 -1))
+ @block.outer)
 
 ; assignment
 
@@ -82,20 +84,23 @@
  @function.outer)
 
 ((function_definition
-  (block_expression (_) @function.inner)
-  .)
+  ("fn"
+   (block_expression) @function.inner)
+   (#offset! @function.inner 0 1 0 -1))
  @function.outer)
 
 ((test_definition
-  (block_expression (_) @function.inner)
-  .)
+  ("test"
+   (block_expression) @function.inner)
+   (#offset! @function.inner 0 1 0 -1))
  @function.outer)
 
 (trait_method_declaration) @function.outer
 
 ((impl_definition
-  (block_expression (_) @function.inner)
-  .)
+  ("impl"
+   (block_expression) @function.inner)
+   (#offset! @function.inner 0 1 0 -1))
  @function.outer)
 
 ; call


### PR DESCRIPTION
When a block starts with `for`, it is unfortunately not considered as part of anything in the block:

![image](https://github.com/user-attachments/assets/c4bf75d9-b44c-4e23-9b04-737a347a36d2)
