### PR TITLE
fix: highlight defer keyword

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -214,6 +214,7 @@
 [
   "guard" "let" "letrec" "and" "const"
   "with" "as" "is" "lexmatch?" "using" "longest" "nobreak"
+  "defer"
 ] @keyword
 
 "derive" @keyword


### PR DESCRIPTION
The `defer` keyword is displayed as bare white letters but it should be a keyword.

In official doc, the `defer` keyword (or I should call it an expression) is printed in same color as variables.

https://docs.moonbitlang.com/en/latest/language/fundamentals.html#defer-expression

But semantetically it is more a keyword than a variable.