### PR TITLE
[codex] Support reverse pipe and constructor functions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -6,6 +6,29 @@ const additive_operators = ["+", "-"];
 const shift_operators = ["<<", ">>"];
 const comparative_operators = [">", ">=", "<=", "<", "==", "!="];
 
+const binaryExpression = (operand) => {
+  /**
+   * @type {[string, RuleOrLiteral][]}
+   */
+  const table = [
+    ["multiplicative", choice(...multiplicative_operators)],
+    ["additive", choice(...additive_operators)],
+    ["shift", choice(...shift_operators)],
+    ["comparative", choice(...comparative_operators)],
+    ["bitwise_and", "&"],
+    ["bitwise_xor", "^"],
+    ["bitwise_or", "|"],
+    ["and", "&&"],
+    ["or", "||"],
+  ];
+
+  return choice(
+    ...table.map(([precedence, operator]) =>
+      prec.left(precedence, seq(operand, operator, operand))
+    )
+  );
+};
+
 module.exports = grammar({
   name: "moonbit",
 
@@ -71,6 +94,8 @@ module.exports = grammar({
     [$._simple_expression, $.positional_parameter],
     [$._simple_type, $.positional_parameter],
     [$._simple_expression, $.arrow_function_expression],
+    [$._simple_expression, $._non_pipe_expression],
+    [$._simple_expression, $._non_pipe_simple_expression],
     [$._simple_pattern, $.lexmatch_simple_pattern],
     [$.list_comprehension_binder, $.for_in_expression],
   ],
@@ -616,6 +641,43 @@ module.exports = grammar({
         "_"
       ),
 
+    _non_pipe_expression: ($) =>
+      choice(
+        $._non_pipe_simple_expression,
+        alias($._non_pipe_binary_expression, $.binary_expression)
+      ),
+
+    _non_pipe_simple_expression: ($) =>
+      choice(
+        $.atomic_expression,
+        $.qualified_identifier,
+        $.unary_expression,
+        $.struct_expression,
+        alias($.nonempty_block_expression, $.block_expression),
+        $.anonymous_lambda_expression,
+        $.anonymous_matrix_lambda_expression,
+        $.constructor_expression,
+        $.apply_expression,
+        $.array_access_expression,
+        $.dot_apply_expression,
+        $.dot_dot_apply_expression,
+        $.access_expression,
+        $.method_expression,
+        $.unit_expression,
+        $.tuple_expression,
+        $.parenthesized_expression,
+        $.constraint_expression,
+        $.array_expression,
+        $.map_expression,
+        $.as_expression,
+        $.is_expression,
+        $.range_expression,
+        $.append_expression,
+        $.lexmatch_test_expression,
+        $.regex_match_expression,
+        "_"
+      ),
+
     atomic_expression: ($) => choice($.string_interpolation, $.literal),
 
     string_interpolation: ($) =>
@@ -730,29 +792,12 @@ module.exports = grammar({
     unary_expression: ($) =>
       seq(choice("-", "+", "!", "not"), $._simple_expression),
 
-    binary_expression: ($) => {
-      /**
-       * @type {[string, RuleOrLiteral][]}
-       */
-      const table = [
-        ["multiplicative", choice(...multiplicative_operators)],
-        ["additive", choice(...additive_operators)],
-        ["shift", choice(...shift_operators)],
-        ["comparative", choice(...comparative_operators)],
-        ["bitwise_and", "&"],
-        ["bitwise_xor", "^"],
-        ["bitwise_or", "|"],
-        ["and", "&&"],
-        ["or", "||"],
-      ];
+    _non_pipe_binary_expression: ($) =>
+      binaryExpression($._non_pipe_expression),
 
-      return choice(
-        ...table.map(([precedence, operator]) =>
-          prec.left(
-            precedence,
-            seq($._simple_expression, operator, $._simple_expression)
-          )
-        ),
+    binary_expression: ($) =>
+      choice(
+        binaryExpression($._simple_expression),
         prec.left(
           "pipe",
           seq(
@@ -764,13 +809,12 @@ module.exports = grammar({
         prec.left(
           "pipe",
           seq(
-            $._simple_expression,
+            $._non_pipe_expression,
             "<|",
-            choice($._simple_expression, $.pipe_arrow_function_expression)
+            choice($._non_pipe_expression, $.pipe_arrow_function_expression)
           )
         )
-      );
-    },
+      ),
 
     struct_expression: ($) =>
       choice(

--- a/grammar.js
+++ b/grammar.js
@@ -45,6 +45,7 @@ module.exports = grammar({
       "bitwise_xor",
       "bitwise_or",
       $.is_expression,
+      $.regex_match_expression,
       "and",
       "or",
       "pipe",
@@ -70,6 +71,7 @@ module.exports = grammar({
     [$._simple_type, $.positional_parameter],
     [$._simple_expression, $.arrow_function_expression],
     [$._simple_pattern, $.lexmatch_simple_pattern],
+    [$.list_comprehension_binder, $.for_in_expression],
   ],
 
   rules: {
@@ -607,6 +609,7 @@ module.exports = grammar({
         $.range_expression,
         $.binary_expression,
         $.lexmatch_test_expression,
+        $.regex_match_expression,
         "_"
       ),
 
@@ -752,6 +755,14 @@ module.exports = grammar({
           seq(
             $._simple_expression,
             "|>",
+            choice($._simple_expression, $.pipe_arrow_function_expression)
+          )
+        ),
+        prec.left(
+          "pipe",
+          seq(
+            $._simple_expression,
+            "<|",
             choice($._simple_expression, $.pipe_arrow_function_expression)
           )
         )
@@ -920,7 +931,34 @@ module.exports = grammar({
     constraint_expression: ($) => seq("(", $._expression, ":", $._type, ")"),
 
     array_expression: ($) =>
-      seq("[", list(",", seq(optional(".."), $._expression)), "]"),
+      choice(
+        seq("[", list(",", seq(optional(".."), $._expression)), "]"),
+        $.list_comprehension_expression
+      ),
+
+    list_comprehension_expression: ($) =>
+      seq(
+        "[",
+        $.list_comprehension_for_in,
+        optional($.list_comprehension_guard),
+        "=>",
+        $._expression,
+        "]"
+      ),
+
+    list_comprehension_for_in: ($) =>
+      seq(
+        "for",
+        strictList1(",", $.list_comprehension_binder),
+        "in",
+        $._expression,
+        optional(seq($._semicolon, strictList(",", $.for_binder))),
+        optional(seq($._semicolon, strictList(",", $.for_binder)))
+      ),
+
+    list_comprehension_binder: ($) => choice($._lowercase_identifier, "_"),
+
+    list_comprehension_guard: ($) => seq("if", $._expression),
 
     map_expression: ($) => seq("{", list(",", $.map_element_expression), "}"),
 
@@ -964,6 +1002,28 @@ module.exports = grammar({
       prec.right(
         -1,
         seq($._simple_expression, "lexmatch?", $.lexmatch_pattern)
+      ),
+
+    regex_match_expression: ($) =>
+      seq($._simple_expression, "=~", $.regex_match_rhs),
+
+    regex_match_rhs: ($) =>
+      choice(
+        $.regex_pattern,
+        seq("(", $.regex_pattern, ",", list(",", $.regex_match_binding), ")")
+      ),
+
+    regex_match_binding: ($) =>
+      choice(seq($._lowercase_identifier, "=", $.identifier), $.label),
+
+    regex_pattern: ($) => $.regex_atom_pattern,
+
+    regex_atom_pattern: ($) =>
+      choice(
+        $.regex_literal,
+        $.string_literal,
+        $.constructor_expression,
+        seq("(", $.regex_pattern, ")")
       ),
 
     case_clause: ($) =>
@@ -1490,7 +1550,8 @@ module.exports = grammar({
     function_identifier: ($) =>
       choice(
         $._lowercase_identifier,
-        seq($.type_name, "::", $._lowercase_identifier)
+        seq($.type_name, "::", $._lowercase_identifier),
+        seq($.type_name, "::", $._uppercase_identifier)
       ),
 
     type_identifier: ($) =>

--- a/grammar.js
+++ b/grammar.js
@@ -37,6 +37,7 @@ module.exports = grammar({
       $.apply_expression,
       $.access_expression,
       $.unary_expression,
+      "append",
       "multiplicative",
       "additive",
       "shift",
@@ -417,6 +418,7 @@ module.exports = grammar({
       seq(
         optional($.attributes),
         optional("async"),
+        optional(seq("fn", optional($.type_parameters))),
         $.function_identifier,
         optional("!"),
         optional($.type_parameters),
@@ -607,6 +609,7 @@ module.exports = grammar({
         $.as_expression,
         $.is_expression,
         $.range_expression,
+        $.append_expression,
         $.binary_expression,
         $.lexmatch_test_expression,
         $.regex_match_expression,
@@ -1004,26 +1007,46 @@ module.exports = grammar({
         seq($._simple_expression, "lexmatch?", $.lexmatch_pattern)
       ),
 
+    append_expression: ($) =>
+      prec.left("append", seq($.left_value, "<+", $._simple_expression)),
+
     regex_match_expression: ($) =>
       seq($._simple_expression, "=~", $.regex_match_rhs),
 
     regex_match_rhs: ($) =>
       choice(
-        $.regex_pattern,
-        seq("(", $.regex_pattern, ",", list(",", $.regex_match_binding), ")")
+        $.regex_atom_pattern,
+        seq("(", $.regex_as_pattern, ",", list(",", $.regex_match_binding), ")")
       ),
 
     regex_match_binding: ($) =>
       choice(seq($._lowercase_identifier, "=", $.identifier), $.label),
 
-    regex_pattern: ($) => $.regex_atom_pattern,
+    regex_pattern: ($) => $.regex_as_pattern,
+
+    regex_as_pattern: ($) =>
+      prec.right(
+        choice(
+          $.regex_or_pattern,
+          seq($.regex_atom_pattern, "as", $.identifier)
+        )
+      ),
+
+    regex_or_pattern: ($) =>
+      prec.left(
+        seq($.regex_sequence_pattern, repeat(seq("|", $.regex_sequence_pattern)))
+      ),
+
+    regex_sequence_pattern: ($) =>
+      prec.left(
+        seq($.regex_atom_pattern, repeat(seq("+", $.regex_atom_pattern)))
+      ),
 
     regex_atom_pattern: ($) =>
       choice(
         $.regex_literal,
-        $.string_literal,
         $.constructor_expression,
-        seq("(", $.regex_pattern, ")")
+        seq("(", $.regex_as_pattern, ")")
       ),
 
     case_clause: ($) =>

--- a/grammar.js
+++ b/grammar.js
@@ -98,6 +98,7 @@ module.exports = grammar({
     [$._simple_expression, $._non_pipe_simple_expression],
     [$._simple_pattern, $.lexmatch_simple_pattern],
     [$.list_comprehension_binder, $.for_in_expression],
+    [$.list_comprehension_for_binder, $._expression],
   ],
 
   rules: {
@@ -986,7 +987,7 @@ module.exports = grammar({
     list_comprehension_expression: ($) =>
       seq(
         "[",
-        $.list_comprehension_for_in,
+        choice($.list_comprehension_for_in, $.list_comprehension_for),
         optional($.list_comprehension_guard),
         "=>",
         $._expression,
@@ -999,9 +1000,42 @@ module.exports = grammar({
         strictList1(",", $.list_comprehension_binder),
         "in",
         $._expression,
-        optional(seq($._semicolon, strictList(",", $.for_binder))),
-        optional(seq($._semicolon, strictList(",", $.for_binder)))
+        optional(
+          seq(
+            $._semicolon,
+            strictList(",", alias($.list_comprehension_for_binder, $.for_binder))
+          )
+        ),
+        optional(
+          seq(
+            $._semicolon,
+            strictList(",", alias($.list_comprehension_for_binder, $.for_binder))
+          )
+        )
       ),
+
+    list_comprehension_for: ($) =>
+      seq(
+        "for",
+        strictList1(",", alias($.list_comprehension_for_binder, $.for_binder)),
+        optional(
+          choice(
+            seq(
+              $._semicolon,
+              optional($._simple_expression),
+              $._semicolon,
+              strictList1(
+                ",",
+                alias($.list_comprehension_for_binder, $.for_binder)
+              )
+            ),
+            seq($._semicolon, $._simple_expression)
+          )
+        )
+      ),
+
+    list_comprehension_for_binder: ($) =>
+      seq($._lowercase_identifier, "=", $._simple_expression),
 
     list_comprehension_binder: ($) => choice($._lowercase_identifier, "_"),
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -314,6 +314,15 @@ static enum AsiResult can_insert_semi(TSLexer *lexer,
     default: // BAR
       return ASI_REMOVE;
     }
+  case '<':
+    advance(lexer);
+    switch (lexer->lookahead) {
+    case '+': // LT_PLUS
+    case '|': // PIPE_LEFT
+      return ASI_REMOVE;
+    default:
+      return ASI_INSERT;
+    }
   case '%':
     advance(lexer);
     switch (lexer->lookahead) {

--- a/test/corpus/expression.txt
+++ b/test/corpus/expression.txt
@@ -184,6 +184,8 @@ list comprehension expression
 ================================================================================
 fn main {
   let xs = [for x in items if x > 0 => x + 1]
+  let ys = [for p1 = 1, p2 = 0;; p1 = p1 + p2, p2 = p1 => p1]
+  let zs = [for i = 0; i < 10 if i % 2 == 0 => i]
 }
 --------------------------------------------------------------------------------
 
@@ -213,7 +215,64 @@ fn main {
                 (lowercase_identifier))
               (atomic_expression
                 (literal
-                  (integer_literal))))))))))
+                  (integer_literal)))))))
+      (let_expression
+        (lowercase_identifier)
+        (array_expression
+          (list_comprehension_expression
+            (list_comprehension_for
+              (for_binder
+                (lowercase_identifier)
+                (atomic_expression
+                  (literal
+                    (integer_literal))))
+              (for_binder
+                (lowercase_identifier)
+                (atomic_expression
+                  (literal
+                    (integer_literal))))
+              (for_binder
+                (lowercase_identifier)
+                (binary_expression
+                  (qualified_identifier
+                    (lowercase_identifier))
+                  (qualified_identifier
+                    (lowercase_identifier))))
+              (for_binder
+                (lowercase_identifier)
+                (qualified_identifier
+                  (lowercase_identifier))))
+            (qualified_identifier
+              (lowercase_identifier)))))
+      (let_expression
+        (lowercase_identifier)
+        (array_expression
+          (list_comprehension_expression
+            (list_comprehension_for
+              (for_binder
+                (lowercase_identifier)
+                (atomic_expression
+                  (literal
+                    (integer_literal))))
+              (binary_expression
+                (qualified_identifier
+                  (lowercase_identifier))
+                (atomic_expression
+                  (literal
+                    (integer_literal)))))
+            (list_comprehension_guard
+              (binary_expression
+                (binary_expression
+                  (qualified_identifier
+                    (lowercase_identifier))
+                  (atomic_expression
+                    (literal
+                      (integer_literal))))
+                (atomic_expression
+                  (literal
+                    (integer_literal)))))
+            (qualified_identifier
+              (lowercase_identifier))))))))
 
 ================================================================================
 regex match expression

--- a/test/corpus/expression.txt
+++ b/test/corpus/expression.txt
@@ -180,6 +180,73 @@ fn main {
         (map_expression)))))
 
 ================================================================================
+list comprehension expression
+================================================================================
+fn main {
+  let xs = [for x in items if x > 0 => x + 1]
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (function_identifier
+      (lowercase_identifier))
+    (block_expression
+      (let_expression
+        (lowercase_identifier)
+        (array_expression
+          (list_comprehension_expression
+            (list_comprehension_for_in
+              (list_comprehension_binder
+                (lowercase_identifier))
+              (qualified_identifier
+                (lowercase_identifier)))
+            (list_comprehension_guard
+              (binary_expression
+                (qualified_identifier
+                  (lowercase_identifier))
+                (atomic_expression
+                  (literal
+                    (integer_literal)))))
+            (binary_expression
+              (qualified_identifier
+                (lowercase_identifier))
+              (atomic_expression
+                (literal
+                  (integer_literal))))))))))
+
+================================================================================
+regex match expression
+================================================================================
+fn main {
+  if s =~ (re"FAILED:", after=next) { next }
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (function_identifier
+      (lowercase_identifier))
+    (block_expression
+      (if_expression
+        (regex_match_expression
+          (qualified_identifier
+            (lowercase_identifier))
+          (regex_match_rhs
+            (regex_pattern
+              (regex_atom_pattern
+                (regex_literal
+                  (string_fragment
+                    (unescaped_string_fragment)))))
+            (regex_match_binding
+              (lowercase_identifier)
+              (identifier
+                (lowercase_identifier)))))
+        (block_expression
+          (qualified_identifier
+            (lowercase_identifier)))))))
+
+================================================================================
 binary expression
 ================================================================================
 fn main {

--- a/test/corpus/expression.txt
+++ b/test/corpus/expression.txt
@@ -233,11 +233,13 @@ fn main {
           (qualified_identifier
             (lowercase_identifier))
           (regex_match_rhs
-            (regex_pattern
-              (regex_atom_pattern
-                (regex_literal
-                  (string_fragment
-                    (unescaped_string_fragment)))))
+            (regex_as_pattern
+              (regex_or_pattern
+                (regex_sequence_pattern
+                  (regex_atom_pattern
+                    (regex_literal
+                      (string_fragment
+                        (unescaped_string_fragment)))))))
             (regex_match_binding
               (lowercase_identifier)
               (identifier
@@ -245,6 +247,118 @@ fn main {
         (block_expression
           (qualified_identifier
             (lowercase_identifier)))))))
+
+================================================================================
+complex regex match expression
+================================================================================
+fn main {
+  if host =~ (
+    re"^" +
+    (re".*" as host) +
+    re":" +
+    (re"[0-9]+" as port_str) +
+    re"$"
+  ) { host }
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (function_identifier
+      (lowercase_identifier))
+    (block_expression
+      (if_expression
+        (regex_match_expression
+          (qualified_identifier
+            (lowercase_identifier))
+          (regex_match_rhs
+            (regex_atom_pattern
+              (regex_as_pattern
+                (regex_or_pattern
+                  (regex_sequence_pattern
+                    (regex_atom_pattern
+                      (regex_literal
+                        (string_fragment
+                          (unescaped_string_fragment))))
+                    (regex_atom_pattern
+                      (regex_as_pattern
+                        (regex_atom_pattern
+                          (regex_literal
+                            (string_fragment
+                              (unescaped_string_fragment))))
+                        (identifier
+                          (lowercase_identifier))))
+                    (regex_atom_pattern
+                      (regex_literal
+                        (string_fragment
+                          (unescaped_string_fragment))))
+                    (regex_atom_pattern
+                      (regex_as_pattern
+                        (regex_atom_pattern
+                          (regex_literal
+                            (string_fragment
+                              (unescaped_string_fragment))))
+                        (identifier
+                          (lowercase_identifier))))
+                    (regex_atom_pattern
+                      (regex_literal
+                        (string_fragment
+                          (unescaped_string_fragment))))))))))
+        (block_expression
+          (qualified_identifier
+            (lowercase_identifier)))))))
+
+================================================================================
+template writing expression
+:language(moonbit)
+================================================================================
+fn main {
+  logger <+ "hello"
+  logger
+    <+
+    "world"
+  logger
+    <+
+    $|line \{x}
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (function_identifier
+      (lowercase_identifier))
+    (block_expression
+      (append_expression
+        (left_value
+          (qualified_identifier
+            (lowercase_identifier)))
+        (atomic_expression
+          (literal
+            (string_literal
+              (string_fragment
+                (unescaped_string_fragment))))))
+      (append_expression
+        (left_value
+          (qualified_identifier
+            (lowercase_identifier)))
+        (atomic_expression
+          (literal
+            (string_literal
+              (string_fragment
+                (unescaped_string_fragment))))))
+      (append_expression
+        (left_value
+          (qualified_identifier
+            (lowercase_identifier)))
+        (atomic_expression
+          (literal
+            (multiline_string_literal
+              (multiline_interpolation_fragment
+                (multiline_interpolation_content)
+                (multiline_interpolation_content
+                  (interpolator
+                    (qualified_identifier
+                      (lowercase_identifier))))))))))))
 
 ================================================================================
 binary expression

--- a/test/corpus/pipe.txt
+++ b/test/corpus/pipe.txt
@@ -204,6 +204,40 @@ fn init {
               (integer_literal))))))))
 
 ================================================================================
+reverse pipe with infix rhs
+================================================================================
+fn init {
+  let a = f <| x + 1
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (function_identifier
+      (lowercase_identifier))
+    (block_expression
+      (let_expression
+        (lowercase_identifier)
+        (binary_expression
+          (qualified_identifier
+            (lowercase_identifier))
+          (binary_expression
+            (qualified_identifier
+              (lowercase_identifier))
+            (atomic_expression
+              (literal
+                (integer_literal)))))))))
+
+================================================================================
+reverse pipe chain is invalid
+:error
+================================================================================
+fn init {
+  let a = f <| g <| x
+}
+--------------------------------------------------------------------------------
+
+================================================================================
 reverse pipe with arrow function
 ================================================================================
 fn init {

--- a/test/corpus/pipe.txt
+++ b/test/corpus/pipe.txt
@@ -159,6 +159,56 @@ fn init {
               (integer_literal))))))))
 
 ================================================================================
+reverse pipe
+================================================================================
+fn init {
+  let a = ignore <| 3
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (function_identifier
+      (lowercase_identifier))
+    (block_expression
+      (let_expression
+        (lowercase_identifier)
+        (binary_expression
+          (qualified_identifier
+            (lowercase_identifier))
+          (atomic_expression
+            (literal
+              (integer_literal))))))))
+
+================================================================================
+reverse pipe with arrow function
+================================================================================
+fn init {
+  let v = ignore <| x => { x + 1 }
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (function_identifier
+      (lowercase_identifier))
+    (block_expression
+      (let_expression
+        (lowercase_identifier)
+        (binary_expression
+          (qualified_identifier
+            (lowercase_identifier))
+          (pipe_arrow_function_expression
+            (lowercase_identifier)
+            (block_expression
+              (binary_expression
+                (qualified_identifier
+                  (lowercase_identifier))
+                (atomic_expression
+                  (literal
+                    (integer_literal)))))))))))
+
+================================================================================
 pipe with arrow function
 ================================================================================
 fn init {

--- a/test/corpus/pipe.txt
+++ b/test/corpus/pipe.txt
@@ -181,6 +181,29 @@ fn init {
               (integer_literal))))))))
 
 ================================================================================
+reverse pipe (line break before operator)
+================================================================================
+fn init {
+  let a = ignore
+    <| 3
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (function_identifier
+      (lowercase_identifier))
+    (block_expression
+      (let_expression
+        (lowercase_identifier)
+        (binary_expression
+          (qualified_identifier
+            (lowercase_identifier))
+          (atomic_expression
+            (literal
+              (integer_literal))))))))
+
+================================================================================
 reverse pipe with arrow function
 ================================================================================
 fn init {

--- a/test/corpus/structure/trait.txt
+++ b/test/corpus/structure/trait.txt
@@ -408,6 +408,48 @@ trait A {
       (trait_method_default_annotation))))
 
 ================================================================================
+trait method with fn header
+================================================================================
+trait A {
+  fn fd(Self) -> @fd_util.Fd
+  async fn[T] get(Self) -> T = _
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (trait_definition
+    (identifier
+      (uppercase_identifier))
+    (trait_method_declaration
+      (function_identifier
+        (lowercase_identifier))
+      (trait_method_parameter
+        (qualified_type_identifier
+          (identifier
+            (uppercase_identifier))))
+      (return_type
+        (qualified_type_identifier
+          (package_identifier)
+          (dot_identifier
+            (dot_uppercase_identifier)))))
+    (trait_method_declaration
+      (type_parameters
+        (type_identifier
+          (identifier
+            (uppercase_identifier))))
+      (function_identifier
+        (lowercase_identifier))
+      (trait_method_parameter
+        (qualified_type_identifier
+          (identifier
+            (uppercase_identifier))))
+      (return_type
+        (qualified_type_identifier
+          (identifier
+            (uppercase_identifier))))
+      (trait_method_default_annotation))))
+
+================================================================================
 trait method with positional & labelled parameters
 ================================================================================
 trait A {

--- a/test/corpus/structure_items.txt
+++ b/test/corpus/structure_items.txt
@@ -447,6 +447,38 @@ fn &Trait::method(self: Self) -> Int { 42 }
           (integer_literal))))))
 
 ================================================================================
+constructor function definition
+================================================================================
+pub fn StringBuilder::StringBuilder() -> StringBuilder {
+  StringBuilder::new()
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (visibility)
+    (function_identifier
+      (type_name
+        (qualified_type_identifier
+          (identifier
+            (uppercase_identifier))))
+      (uppercase_identifier))
+    (parameters)
+    (return_type
+      (qualified_type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (block_expression
+      (apply_expression
+        (method_expression
+          (type_name
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier))))
+          (lowercase_identifier))
+        (arguments)))))
+
+================================================================================
 Test
 ================================================================================
 


### PR DESCRIPTION
## Summary

- Add grammar support for reverse pipe expressions using `<|`.
- Allow uppercase constructor-style function names such as `pub fn Type::Type(...)`.
- Add parsing support needed by the current `moonbitlang/core` sources for list comprehensions and regex match expressions.
- Cover the new syntax with corpus tests.

## Notes

Generated parser artifacts are intentionally not included in this PR. CI regenerates them before running parser and binding tests, matching the current repository workflow.

## Validation

- `npm run lint`
- `python3 scripts/generate.py`
- `python3 scripts/test.py`
- `tree-sitter parse --quiet --stat --paths /private/tmp/tree-sitter-moonbit-core-source-paths.txt` (`701/701` local core `.mbt`/`.mbti` files parsed successfully)