### PR TITLE
[codex] Highlight byte literals

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -284,6 +284,7 @@
 
 (string_interpolation) @string
 (string_literal) @string
+(bytes_literal) @string
 (multiline_string_literal) @string
 (escape_sequence) @string.escape
 
@@ -294,6 +295,8 @@
 (integer_literal) @number
 (float_literal) @number.float
 (boolean_literal) @boolean
+(byte_literal) @character
+(byte_escape_literal) @character
 (char_literal) @character
 
 ;; Comments

--- a/test/highlight/bytes.mbt
+++ b/test/highlight/bytes.mbt
@@ -1,0 +1,11 @@
+///|
+fn main {
+  let a = b"abc"
+  //      ^^^^^^ string
+  let b = b"\x00\xff"
+  //      ^^^^^^^^^^^ string
+  let c = b'a'
+  //      ^^^^ character
+  let d = b'\x7f'
+  //      ^^^^^^^ character
+}


### PR DESCRIPTION
## Summary

- Highlight `bytes_literal` nodes as strings in Tree-sitter queries.
- Highlight `byte_literal` and standalone `byte_escape_literal` nodes as characters.
- Add a highlight fixture covering bytes and byte literals.

## Why

MoonBit `b"..."` bytes literals parse as `bytes_literal`, but the highlight query only captured `string_literal` and `multiline_string_literal`. As a result bytes literals had no string highlighting in Neovim consumers of this query.

## Validation

- `env XDG_CACHE_HOME=/tmp/tree-sitter-cache tree-sitter test`
- `npm run lint`