### PR TITLE
feat(grammar): support extenum syntax

### DIFF
--- a/docs/plans/plan.md
+++ b/docs/plans/plan.md
@@ -316,6 +316,7 @@ does not include `extenum`.
   definitions.
 - `queries/tags.scm`: expose `extenum_definition` as a class/type definition.
 - `queries/folds.scm`: add fold coverage for both `extenum` forms.
+- `test/highlight/extenum.mbt`: assert declaration and extension highlighting.
 - `test/corpus/*`: add parser coverage for local declarations, local
   extensions, and foreign package extensions.
 - Generated parser artifacts under `src/` and `grammars/quotation/src/` are

--- a/docs/plans/plan.md
+++ b/docs/plans/plan.md
@@ -281,3 +281,70 @@ re-run the PR #250 validation sweep.
 - Parse local `~/Workspace/moonbit/core` tracked `.mbt`/`.mbti` files.
 - Parse local `~/Workspace/moonbit/async` tracked `.mbt` files.
 - Push to #250 and verify GitHub PR checks.
+
+# Extensible Enum Syntax
+
+## Goal
+
+Support parsing MoonBit's `extenum` declarations and extensions, matching the
+compiler grammar in `compiler/ideas`.
+
+## Accepted Design
+
+Add separate named nodes for the two semantic forms:
+
+- `extenum_definition` for open enum declarations such as
+  `pub extenum Expr[T] { ... }`
+- `extenum_extension` for constructor extensions such as
+  `extenum Expr[T] += { ... }` and `pub extenum @pkg.Expr[T] += { ... }`
+
+Both forms reuse the existing enum constructor, constructor payload, type
+parameter, visibility, attributes, and derive directive grammar. The new rules
+also accept the compiler-supported `declare` modifier before visibility.
+
+`extenum` is added only as a toplevel structure item. It is not added to block
+statement expressions because the compiler's local type declaration grammar
+does not include `extenum`.
+
+## Target Files And Surfaces
+
+- `grammar.js`: add `extenum_definition` and `extenum_extension` structure item
+  rules.
+- `queries/highlights.scm`: highlight `extenum_definition` names as type
+  definitions and `extenum_extension` targets as type references.
+- `queries/locals.scm`: bind only `extenum_definition` names as local type
+  definitions.
+- `queries/tags.scm`: expose `extenum_definition` as a class/type definition.
+- `queries/folds.scm`: add fold coverage for both `extenum` forms.
+- `test/corpus/*`: add parser coverage for local declarations, local
+  extensions, and foreign package extensions.
+- Generated parser artifacts under `src/` and `grammars/quotation/src/` are
+  refreshed only for local validation and intentionally not committed unless a
+  later explicit decision says otherwise.
+
+## API And Interface Diff
+
+Generated `src/node-types.json` gains two named node types:
+
+- `extenum_definition`
+- `extenum_extension`
+
+No existing named node types are removed or renamed. Existing enum constructor
+node shapes are reused.
+
+## Open Questions
+
+None. `declare` support is included for the new `extenum` forms only; extending
+old `struct`, `enum`, or `type` declaration rules is intentionally out of
+scope.
+
+## Next Implementation Step
+
+Patch the grammar, query files, and corpus coverage, then regenerate the parser
+for local validation.
+
+## Validation Plan
+
+- Run `python3 scripts/generate.py`.
+- Run `tree-sitter test`.
+- Run `npm run lint`.

--- a/grammar.js
+++ b/grammar.js
@@ -100,6 +100,7 @@ module.exports = grammar({
     [$.list_comprehension_for_binder, $._expression],
     [$.block_expression, $.map_expression],
     [$.block_expression, $.nonempty_block_expression],
+    [$.extenum_definition, $._extenum_extension_target],
   ],
 
   rules: {
@@ -116,6 +117,8 @@ module.exports = grammar({
         $.struct_definition,
         $.tuple_struct_definition,
         $.enum_definition,
+        $.extenum_definition,
+        $.extenum_extension,
         $.value_definition,
         $.const_definition,
         $.function_definition,
@@ -326,6 +329,36 @@ module.exports = grammar({
         "}",
         optional($.derive_directive)
       ),
+
+    extenum_definition: ($) =>
+      seq(
+        optional($.attributes),
+        optional("declare"),
+        optional($.visibility),
+        "extenum",
+        $.identifier,
+        optional($.type_parameters),
+        $._extenum_body,
+        optional($.derive_directive)
+      ),
+
+    extenum_extension: ($) =>
+      seq(
+        optional($.attributes),
+        optional("declare"),
+        optional($.visibility),
+        "extenum",
+        $._extenum_extension_target,
+        optional($.type_parameters),
+        "+=",
+        $._extenum_body,
+        optional($.derive_directive)
+      ),
+
+    _extenum_extension_target: ($) =>
+      choice($.identifier, seq($.package_identifier, $.dot_uppercase_identifier)),
+
+    _extenum_body: ($) => seq("{", list($._semicolon, $.enum_constructor), "}"),
 
     enum_constructor_payload: ($) =>
       choice(

--- a/queries/folds.scm
+++ b/queries/folds.scm
@@ -3,6 +3,8 @@
   (match_expression)
   (struct_definition)
   (enum_definition)
+  (extenum_definition)
+  (extenum_extension)
   (function_definition)
   (value_definition)
   (if_expression)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -73,6 +73,7 @@
 ; Type definitions
 
 (enum_definition (identifier) @type.definition)
+(extenum_definition (identifier) @type.definition)
 (struct_definition (identifier) @type.definition)
 (tuple_struct_definition (identifier) @type.definition)
 (type_definition (identifier) @type.definition)
@@ -84,6 +85,8 @@
 (trait_alias_targets (identifier) @type.definition)
 (trait_alias_targets (dot_identifier) @type.definition)
 (trait_alias_target (identifier) @type.definition)
+(extenum_extension (identifier) @type)
+(extenum_extension (dot_uppercase_identifier) @type)
 
 ; Builtin types
 
@@ -205,11 +208,11 @@
 [ (mutability) "mut" ] @keyword.modifier
 
 [
-  "struct" "enum" "type" "trait" "typealias" "traitalias" "suberror"
+  "struct" "enum" "extenum" "type" "trait" "typealias" "traitalias" "suberror"
 ] @keyword.type
 
 [
-  "pub" "priv" "readonly" "all" "open" "extern"
+  "pub" "priv" "readonly" "all" "open" "extern" "declare"
 ] @keyword.modifier
 
 [

--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -19,6 +19,7 @@
 
 (struct_definition (identifier) @local.definition)
 (enum_definition (identifier) @local.definition)
+(extenum_definition (identifier) @local.definition)
 (type_definition (identifier) @local.definition)
 (type_identifier) @local.definition
 

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -28,6 +28,8 @@
     (identifier) @name) @definition.class
    (enum_definition
     (identifier) @name) @definition.class
+   (extenum_definition
+    (identifier) @name) @definition.class
    (error_type_definition
     (identifier) @name) @definition.class
  ]

--- a/test/corpus/extenum.txt
+++ b/test/corpus/extenum.txt
@@ -1,0 +1,259 @@
+================================================================================
+extenum declaration
+================================================================================
+pub extenum Expr[T] {
+  Int(T)
+  Add(Expr[T], Expr[T])
+} derive(Debug)
+--------------------------------------------------------------------------------
+
+(structure
+  (extenum_definition
+    (visibility)
+    (identifier
+      (uppercase_identifier))
+    (type_parameters
+      (type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (enum_constructor
+      (uppercase_identifier)
+      (enum_constructor_payload
+        (constructor_parameter
+          (qualified_type_identifier
+            (identifier
+              (uppercase_identifier))))))
+    (enum_constructor
+      (uppercase_identifier)
+      (enum_constructor_payload
+        (constructor_parameter
+          (apply_type
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))
+            (type_arguments
+              (qualified_type_identifier
+                (identifier
+                  (uppercase_identifier))))))
+        (constructor_parameter
+          (apply_type
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))
+            (type_arguments
+              (qualified_type_identifier
+                (identifier
+                  (uppercase_identifier))))))))
+    (derive_directive
+      (derive_item
+        (type_name
+          (qualified_type_identifier
+            (identifier
+              (uppercase_identifier))))))))
+
+================================================================================
+extenum local extension
+================================================================================
+extenum Expr[T] += {
+  Mul(Expr[T], Expr[T])
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (extenum_extension
+    (identifier
+      (uppercase_identifier))
+    (type_parameters
+      (type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (enum_constructor
+      (uppercase_identifier)
+      (enum_constructor_payload
+        (constructor_parameter
+          (apply_type
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))
+            (type_arguments
+              (qualified_type_identifier
+                (identifier
+                  (uppercase_identifier))))))
+        (constructor_parameter
+          (apply_type
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))
+            (type_arguments
+              (qualified_type_identifier
+                (identifier
+                  (uppercase_identifier))))))))))
+
+================================================================================
+extenum foreign extension
+================================================================================
+declare pub extenum @pkg.Expr[T] += {
+  Let(String, @pkg.Expr[T], @pkg.Expr[T])
+} derive(Debug)
+--------------------------------------------------------------------------------
+
+(structure
+  (extenum_extension
+    (visibility)
+    (package_identifier)
+    (dot_uppercase_identifier)
+    (type_parameters
+      (type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (enum_constructor
+      (uppercase_identifier)
+      (enum_constructor_payload
+        (constructor_parameter
+          (qualified_type_identifier
+            (identifier
+              (uppercase_identifier))))
+        (constructor_parameter
+          (apply_type
+            (qualified_type_identifier
+              (package_identifier)
+              (dot_identifier
+                (dot_uppercase_identifier)))
+            (type_arguments
+              (qualified_type_identifier
+                (identifier
+                  (uppercase_identifier))))))
+        (constructor_parameter
+          (apply_type
+            (qualified_type_identifier
+              (package_identifier)
+              (dot_identifier
+                (dot_uppercase_identifier)))
+            (type_arguments
+              (qualified_type_identifier
+                (identifier
+                  (uppercase_identifier))))))))
+    (derive_directive
+      (derive_item
+        (type_name
+          (qualified_type_identifier
+            (identifier
+              (uppercase_identifier))))))))
+
+================================================================================
+extenum compiler sample
+================================================================================
+pub extenum Expr[T] {
+  Int(T)
+  Add(Expr[T], Expr[T])
+}
+
+extenum Expr[T] += {
+  Mul(Expr[T], Expr[T])
+}
+
+pub extenum @pkg.Expr[T] += {
+  Let(String, @pkg.Expr[T], @pkg.Expr[T])
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (extenum_definition
+    (visibility)
+    (identifier
+      (uppercase_identifier))
+    (type_parameters
+      (type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (enum_constructor
+      (uppercase_identifier)
+      (enum_constructor_payload
+        (constructor_parameter
+          (qualified_type_identifier
+            (identifier
+              (uppercase_identifier))))))
+    (enum_constructor
+      (uppercase_identifier)
+      (enum_constructor_payload
+        (constructor_parameter
+          (apply_type
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))
+            (type_arguments
+              (qualified_type_identifier
+                (identifier
+                  (uppercase_identifier))))))
+        (constructor_parameter
+          (apply_type
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))
+            (type_arguments
+              (qualified_type_identifier
+                (identifier
+                  (uppercase_identifier)))))))))
+  (extenum_extension
+    (identifier
+      (uppercase_identifier))
+    (type_parameters
+      (type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (enum_constructor
+      (uppercase_identifier)
+      (enum_constructor_payload
+        (constructor_parameter
+          (apply_type
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))
+            (type_arguments
+              (qualified_type_identifier
+                (identifier
+                  (uppercase_identifier))))))
+        (constructor_parameter
+          (apply_type
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))
+            (type_arguments
+              (qualified_type_identifier
+                (identifier
+                  (uppercase_identifier)))))))))
+  (extenum_extension
+    (visibility)
+    (package_identifier)
+    (dot_uppercase_identifier)
+    (type_parameters
+      (type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (enum_constructor
+      (uppercase_identifier)
+      (enum_constructor_payload
+        (constructor_parameter
+          (qualified_type_identifier
+            (identifier
+              (uppercase_identifier))))
+        (constructor_parameter
+          (apply_type
+            (qualified_type_identifier
+              (package_identifier)
+              (dot_identifier
+                (dot_uppercase_identifier)))
+            (type_arguments
+              (qualified_type_identifier
+                (identifier
+                  (uppercase_identifier))))))
+        (constructor_parameter
+          (apply_type
+            (qualified_type_identifier
+              (package_identifier)
+              (dot_identifier
+                (dot_uppercase_identifier)))
+            (type_arguments
+              (qualified_type_identifier
+                (identifier
+                  (uppercase_identifier))))))))))

--- a/test/highlight/extenum.mbt
+++ b/test/highlight/extenum.mbt
@@ -1,0 +1,27 @@
+///|
+extenum Event {
+// <- keyword.type
+//      ^^^^^ type.definition
+  Started
+  // <- constructor
+}
+
+///|
+extenum Event += {
+// <- keyword.type
+//      ^^^^^ type
+//            ^^ operator
+  Stopped
+  // <- constructor
+}
+
+///|
+declare extenum @base.Event += {
+// <- keyword.modifier
+//      ^^^^^^^ keyword.type
+//              ^^^^^ module
+//                   ^^^^^^ type
+//                          ^^ operator
+  Paused
+  // <- constructor
+}


### PR DESCRIPTION
## Summary

- parse `extenum` declarations and local or package-qualified extensions
- expose dedicated `extenum_definition` and `extenum_extension` nodes
- update highlight, locals, tags, and folds queries
- cover the grammar with corpus tests and 13 highlight assertions

## Why

MoonBit supports extensible enums, but the grammar did not recognize their declarations or extension forms. This caused valid source to parse incorrectly and left editor queries without stable nodes to target.

## Validation

- `tree-sitter generate` for the main, mbtp, and quotation grammars
- `tree-sitter test` — main 292/292, mbtp 5/5, quotation 7/7
- `npm run lint`
- `go test -mod=mod ./bindings/go`
- `cargo test`
- local core/async parse comparison against `upstream/main`: no new failing files

Generated parser artifacts were refreshed for validation and intentionally left uncommitted, matching the repository policy.