### PR TITLE
fix(ci): propagate parser command failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
     paths:
       - grammar.js
+      - scripts/**
       - src/**
       - bindings/**
       - binding.gyp
@@ -12,6 +13,7 @@ on:
   pull_request:
     paths:
       - grammar.js
+      - scripts/**
       - src/**
       - bindings/**
       - binding.gyp
@@ -28,6 +30,9 @@ jobs:
         uses: tree-sitter/setup-action/cli@v2
         with:
           tree-sitter-ref: v0.26.8
+
+      - name: Test scripts
+        run: python3 -m unittest scripts/test_exit_codes.py
 
       - name: Generate tree-sitter parser
         run: python3 scripts/generate.py

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -13,9 +13,15 @@ def main():
         process = subprocess.Popen(["tree-sitter", "generate"], cwd=grammar["path"])
         processes.append(process)
 
+    exit_code = 0
     for process in processes:
-        process.wait()
+        return_code = process.wait()
+        # Wait for every grammar, but preserve the first child failure for CI.
+        if return_code != 0 and exit_code == 0:
+            exit_code = return_code
+
+    return exit_code
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -13,9 +13,15 @@ def main():
         process = subprocess.Popen(["tree-sitter", "test"], cwd=grammar["path"])
         processes.append(process)
 
+    exit_code = 0
     for process in processes:
-        process.wait()
+        return_code = process.wait()
+        # Wait for every grammar, but preserve the first child failure for CI.
+        if return_code != 0 and exit_code == 0:
+            exit_code = return_code
+
+    return exit_code
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/test_exit_codes.py
+++ b/scripts/test_exit_codes.py
@@ -1,0 +1,37 @@
+import runpy
+import unittest
+from unittest.mock import Mock, patch
+
+
+class ScriptExitCodeTests(unittest.TestCase):
+    def test_generate_exits_with_first_child_failure(self):
+        processes = [Mock(), Mock(), Mock()]
+        processes[0].wait.return_value = 0
+        processes[1].wait.return_value = 7
+        processes[2].wait.return_value = 9
+
+        with patch("subprocess.Popen", side_effect=processes):
+            with self.assertRaises(SystemExit) as result:
+                runpy.run_path("scripts/generate.py", run_name="__main__")
+
+        self.assertEqual(result.exception.code, 7)
+        for process in processes:
+            process.wait.assert_called_once_with()
+
+    def test_test_exits_with_first_child_failure(self):
+        processes = [Mock(), Mock(), Mock()]
+        processes[0].wait.return_value = 3
+        processes[1].wait.return_value = 0
+        processes[2].wait.return_value = 5
+
+        with patch("subprocess.Popen", side_effect=processes):
+            with self.assertRaises(SystemExit) as result:
+                runpy.run_path("scripts/test.py", run_name="__main__")
+
+        self.assertEqual(result.exception.code, 3)
+        for process in processes:
+            process.wait.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- return the first non-zero child exit code from `scripts/generate.py` and `scripts/test.py`
- continue waiting for every concurrently started grammar command before exiting
- add regression tests for failure propagation and process cleanup
- trigger the test workflow for `scripts/**` changes and run the regression tests in CI

## Root cause

Both scripts called `Popen.wait()` but discarded its return value. The Python process therefore exited successfully even when one or more `tree-sitter` commands failed, allowing the CI step to report a false success.

## Impact

Generation and parser-test failures now make the wrapper script fail with the first child failure code, while all started child processes are still reaped. Script-only pull requests also execute the workflow that validates this behavior.

## Validation

- `python3 -m unittest scripts/test_exit_codes.py` — 2/2 passed
- `python3 scripts/generate.py`
- `python3 scripts/test.py` — main 288/288, mbtp 5/5, quotation 7/7