### PR TITLE
[codex] support or-pattern defaults

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1461,13 +1461,12 @@ module.exports = grammar({
     // lower precedence than `|`, so a grouped fallback can cover several arms.
     default_pattern: ($) =>
       prec.right(
-        seq(
-          $._pattern,
-          "with",
-          $._lowercase_identifier,
-          "=",
-          $._non_pipe_expression
-        )
+        seq($._pattern, "with", list1(",", $.default_pattern_binding))
+      ),
+
+    default_pattern_binding: ($) =>
+      prec.right(
+        seq($._lowercase_identifier, "=", $._non_pipe_expression)
       ),
 
     _simple_pattern: ($) =>

--- a/grammar.js
+++ b/grammar.js
@@ -80,7 +80,7 @@ module.exports = grammar({
     [$.array_access_expression, $.unary_expression],
     [$.unary_expression, $.range_expression],
     [$.unary_expression, $.as_expression],
-    [$.or_pattern, $.as_pattern],
+    [$.or_pattern, $.as_pattern, $.default_pattern],
     [$.lexmatch_or_pattern, $.lexmatch_as_pattern],
   ],
 
@@ -1445,11 +1445,30 @@ module.exports = grammar({
     // Patterns
 
     _pattern: ($) =>
-      choice($._simple_pattern, $.range_pattern, $.as_pattern, $.or_pattern),
+      choice(
+        $._simple_pattern,
+        $.range_pattern,
+        $.as_pattern,
+        $.or_pattern,
+        $.default_pattern
+      ),
 
     as_pattern: ($) => seq($._pattern, "as", $._lowercase_identifier),
 
     or_pattern: ($) => prec.right(seq($._pattern, "|", $._pattern)),
+
+    // `with` supplies bindings missing from one side of an or-pattern. It has
+    // lower precedence than `|`, so a grouped fallback can cover several arms.
+    default_pattern: ($) =>
+      prec.right(
+        seq(
+          $._pattern,
+          "with",
+          $._lowercase_identifier,
+          "=",
+          $._non_pipe_expression
+        )
+      ),
 
     _simple_pattern: ($) =>
       choice(

--- a/test/corpus/pattern.txt
+++ b/test/corpus/pattern.txt
@@ -80,6 +80,7 @@ fn main {
   match optional_value {
     Some(value) | (None with value = default) => value
     Some([value, ..]) | (Some([]) | None with value = default) => value
+    Present(a, b) | (Missing with a = default_a, b = default_b) => (a, b)
   }
 }
 --------------------------------------------------------------------------------
@@ -104,9 +105,10 @@ fn main {
                 (constructor_pattern
                   (constructor_expression
                     (uppercase_identifier)))
-                (lowercase_identifier)
-                (qualified_identifier
-                  (lowercase_identifier)))))
+                (default_pattern_binding
+                  (lowercase_identifier)
+                  (qualified_identifier
+                    (lowercase_identifier))))))
           (qualified_identifier
             (lowercase_identifier)))
         (case_clause
@@ -130,11 +132,39 @@ fn main {
                   (constructor_pattern
                     (constructor_expression
                       (uppercase_identifier))))
-                (lowercase_identifier)
-                (qualified_identifier
-                  (lowercase_identifier)))))
+                (default_pattern_binding
+                  (lowercase_identifier)
+                  (qualified_identifier
+                    (lowercase_identifier))))))
           (qualified_identifier
-            (lowercase_identifier)))))))
+            (lowercase_identifier)))
+        (case_clause
+          (or_pattern
+            (constructor_pattern
+              (constructor_expression
+                (uppercase_identifier))
+              (constructor_pattern_argument
+                (lowercase_identifier))
+              (constructor_pattern_argument
+                (lowercase_identifier)))
+            (parenthesized_pattern
+              (default_pattern
+                (constructor_pattern
+                  (constructor_expression
+                    (uppercase_identifier)))
+                (default_pattern_binding
+                  (lowercase_identifier)
+                  (qualified_identifier
+                    (lowercase_identifier)))
+                (default_pattern_binding
+                  (lowercase_identifier)
+                  (qualified_identifier
+                    (lowercase_identifier))))))
+          (tuple_expression
+            (qualified_identifier
+              (lowercase_identifier))
+            (qualified_identifier
+              (lowercase_identifier))))))))
 
 ================================================================================
 literal pattern

--- a/test/corpus/pattern.txt
+++ b/test/corpus/pattern.txt
@@ -74,6 +74,69 @@ fn main {
           (unit_expression))))))
 
 ================================================================================
+or-pattern default bindings
+================================================================================
+fn main {
+  match optional_value {
+    Some(value) | (None with value = default) => value
+    Some([value, ..]) | (Some([]) | None with value = default) => value
+  }
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (function_identifier
+      (lowercase_identifier))
+    (block_expression
+      (match_expression
+        (qualified_identifier
+          (lowercase_identifier))
+        (case_clause
+          (or_pattern
+            (constructor_pattern
+              (constructor_expression
+                (uppercase_identifier))
+              (constructor_pattern_argument
+                (lowercase_identifier)))
+            (parenthesized_pattern
+              (default_pattern
+                (constructor_pattern
+                  (constructor_expression
+                    (uppercase_identifier)))
+                (lowercase_identifier)
+                (qualified_identifier
+                  (lowercase_identifier)))))
+          (qualified_identifier
+            (lowercase_identifier)))
+        (case_clause
+          (or_pattern
+            (constructor_pattern
+              (constructor_expression
+                (uppercase_identifier))
+              (constructor_pattern_argument
+                (array_pattern
+                  (array_sub_pattern
+                    (lowercase_identifier))
+                  (array_sub_pattern))))
+            (parenthesized_pattern
+              (default_pattern
+                (or_pattern
+                  (constructor_pattern
+                    (constructor_expression
+                      (uppercase_identifier))
+                    (constructor_pattern_argument
+                      (array_pattern)))
+                  (constructor_pattern
+                    (constructor_expression
+                      (uppercase_identifier))))
+                (lowercase_identifier)
+                (qualified_identifier
+                  (lowercase_identifier)))))
+          (qualified_identifier
+            (lowercase_identifier)))))))
+
+================================================================================
 literal pattern
 ================================================================================
 fn main {


### PR DESCRIPTION
## Summary

- parse `with` default bindings in or-pattern alternatives
- keep `with` lower precedence than `|` for grouped fallback patterns
- add corpus coverage for simple and nested alternatives

## Why

Current `moonbitlang/core` uses forms such as `Some(value) | (None with value = default)`. The parser previously produced `ERROR` nodes for these patterns.

## Validation

- `python3 scripts/generate.py`
- `python3 scripts/test.py` (293/293 root corpus tests, 7/7 quotation, 5/5 mbtp)
- `tree-sitter parse --quiet` on the 23 affected core files
- `npm run lint`
