### PR TITLE
[codex] support lexscan syntax

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -633,6 +633,7 @@ module.exports = grammar({
         $.loop_expression,
         $.match_expression,
         $.lexmatch_expression,
+        $.lexscan_expression,
         $.for_expression,
         $.for_in_expression,
         $.try_catch_expression,
@@ -1136,6 +1137,40 @@ module.exports = grammar({
         "{",
         list($._semicolon, $.lexmatch_case_clause),
         "}"
+      ),
+
+    // Unlike lexmatch, lexscan accepts regex captures as well as a binder for
+    // the complete token. Both forms share the existing regex pattern grammar.
+    lexscan_expression: ($) =>
+      seq(
+        "lexscan",
+        $._simple_expression,
+        optional(seq("with", $._lowercase_identifier)),
+        "{",
+        list($._semicolon, $.lexscan_case_clause),
+        "}"
+      ),
+
+    lexscan_case_clause: ($) =>
+      seq(
+        $.lexscan_case_pattern,
+        optional($.pattern_guard),
+        "=>",
+        $._statement_expression
+      ),
+
+    lexscan_case_pattern: ($) =>
+      choice(
+        $.regex_pattern,
+        seq(
+          "(",
+          $.regex_pattern,
+          ",",
+          list1(",", $.regex_match_binding),
+          ")"
+        ),
+        $._lowercase_identifier,
+        $.any_pattern
       ),
 
     lexmatch_test_expression: ($) =>

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -218,7 +218,7 @@
 
 [
   "guard" "let" "letrec" "and" "const"
-  "with" "as" "is" "lexmatch?" "using" "where" "longest" "nobreak"
+  "with" "as" "is" "lexmatch?" "lexscan" "using" "where" "longest" "nobreak"
   "defer"
 ] @keyword
 

--- a/test/corpus/lexscan.txt
+++ b/test/corpus/lexscan.txt
@@ -1,0 +1,113 @@
+================================================================================
+lexscan expressions
+================================================================================
+fn init {
+  lexscan lexbuf {
+    re"[0-9]+" => ()
+    re"[a-z]+" if is_alpha => ()
+    Token => ()
+    x => x
+    _ => ()
+  }
+  lexscan source with longest {
+    ((re"if" | re"else") as keyword, before=prefix, after~) => prefix
+    @pkg.Token => ()
+  }
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (function_identifier
+      (lowercase_identifier))
+    (block_expression
+      (lexscan_expression
+        (qualified_identifier
+          (lowercase_identifier))
+        (lexscan_case_clause
+          (lexscan_case_pattern
+            (regex_pattern
+              (regex_as_pattern
+                (regex_or_pattern
+                  (regex_sequence_pattern
+                    (regex_atom_pattern
+                      (regex_literal
+                        (string_fragment
+                          (unescaped_string_fragment)))))))))
+          (unit_expression))
+        (lexscan_case_clause
+          (lexscan_case_pattern
+            (regex_pattern
+              (regex_as_pattern
+                (regex_or_pattern
+                  (regex_sequence_pattern
+                    (regex_atom_pattern
+                      (regex_literal
+                        (string_fragment
+                          (unescaped_string_fragment)))))))))
+          (pattern_guard
+            (qualified_identifier
+              (lowercase_identifier)))
+          (unit_expression))
+        (lexscan_case_clause
+          (lexscan_case_pattern
+            (regex_pattern
+              (regex_as_pattern
+                (regex_or_pattern
+                  (regex_sequence_pattern
+                    (regex_atom_pattern
+                      (constructor_expression
+                        (uppercase_identifier))))))))
+          (unit_expression))
+        (lexscan_case_clause
+          (lexscan_case_pattern
+            (lowercase_identifier))
+          (qualified_identifier
+            (lowercase_identifier)))
+        (lexscan_case_clause
+          (lexscan_case_pattern
+            (any_pattern))
+          (unit_expression)))
+      (lexscan_expression
+        (qualified_identifier
+          (lowercase_identifier))
+        (lowercase_identifier)
+        (lexscan_case_clause
+          (lexscan_case_pattern
+            (regex_pattern
+              (regex_as_pattern
+                (regex_atom_pattern
+                  (regex_as_pattern
+                    (regex_or_pattern
+                      (regex_sequence_pattern
+                        (regex_atom_pattern
+                          (regex_literal
+                            (string_fragment
+                              (unescaped_string_fragment)))))
+                      (regex_sequence_pattern
+                        (regex_atom_pattern
+                          (regex_literal
+                            (string_fragment
+                              (unescaped_string_fragment))))))))
+                (identifier
+                  (lowercase_identifier))))
+            (regex_match_binding
+              (lowercase_identifier)
+              (identifier
+                (lowercase_identifier)))
+            (regex_match_binding
+              (label
+                (lowercase_identifier))))
+          (qualified_identifier
+            (lowercase_identifier)))
+        (lexscan_case_clause
+          (lexscan_case_pattern
+            (regex_pattern
+              (regex_as_pattern
+                (regex_or_pattern
+                  (regex_sequence_pattern
+                    (regex_atom_pattern
+                      (constructor_expression
+                        (package_identifier)
+                        (dot_uppercase_identifier))))))))
+          (unit_expression))))))

--- a/test/highlight/lexscan.mbt
+++ b/test/highlight/lexscan.mbt
@@ -1,0 +1,7 @@
+///|
+fn scan(source : StringView) -> Unit {
+  lexscan source with longest {
+  // <- keyword
+    re"[a-z]+" => ()
+  }
+}


### PR DESCRIPTION
## Summary

- parse `lexscan` expressions with optional strategies
- support regex captures, token binders, constructor patterns, guards, and wildcards
- highlight the `lexscan` keyword and cover it directly

## Why

Current `moonbitlang/core` uses `lexscan` for source locations, number parsing, and regex parsing. The grammar previously supported `lexmatch` but produced `ERROR` nodes for `lexscan`.

## Validation

- `python3 scripts/generate.py`
- `python3 scripts/test.py` (293/293 root corpus tests, 7/7 quotation, 5/5 mbtp)
- `tree-sitter parse --quiet` on the eight affected core files
- `test/highlight/lexscan.mbt` (1 assertion)
- `npm run lint`
