### PR TITLE
[codex] support declared functions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -411,6 +411,9 @@ module.exports = grammar({
     function_definition: ($) => {
       const signature = seq(
         optional($.attributes),
+        // Keep declared functions in the same node so existing symbol queries
+        // treat their names exactly like implemented functions.
+        optional("declare"),
         optional($.visibility),
         optional($.external_linkage),
         optional("async"),

--- a/test/corpus/declare.txt
+++ b/test/corpus/declare.txt
@@ -1,0 +1,90 @@
+================================================================================
+declared functions
+================================================================================
+declare fn find_byte(target : BytesView, byte : Byte) -> Int
+
+declare pub fn[T : Show] format(value : T) -> String
+
+declare pub async fn Reader::read(self : Reader) -> Int
+
+declare pub fn fallible() -> Int raise
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (function_identifier
+      (lowercase_identifier))
+    (parameters
+      (parameter
+        (positional_parameter
+          (lowercase_identifier)
+          (type_annotation
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier))))))
+      (parameter
+        (positional_parameter
+          (lowercase_identifier)
+          (type_annotation
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))))))
+    (return_type
+      (qualified_type_identifier
+        (identifier
+          (uppercase_identifier)))))
+  (function_definition
+    (visibility)
+    (type_parameters
+      (type_identifier
+        (identifier
+          (uppercase_identifier))
+        (constraints
+          (constraint
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))))))
+    (function_identifier
+      (lowercase_identifier))
+    (parameters
+      (parameter
+        (positional_parameter
+          (lowercase_identifier)
+          (type_annotation
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))))))
+    (return_type
+      (qualified_type_identifier
+        (identifier
+          (uppercase_identifier)))))
+  (function_definition
+    (visibility)
+    (function_identifier
+      (type_name
+        (qualified_type_identifier
+          (identifier
+            (uppercase_identifier))))
+      (lowercase_identifier))
+    (parameters
+      (parameter
+        (positional_parameter
+          (lowercase_identifier)
+          (type_annotation
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))))))
+    (return_type
+      (qualified_type_identifier
+        (identifier
+          (uppercase_identifier)))))
+  (function_definition
+    (visibility)
+    (function_identifier
+      (lowercase_identifier))
+    (parameters)
+    (return_type
+      (qualified_type_identifier
+        (identifier
+          (uppercase_identifier)))
+      (error_annotation))))


### PR DESCRIPTION
## Summary

- accept `declare` before function visibility and `async`
- preserve the existing `function_definition` node and symbol-query behavior
- cover private, public generic, async method, and raising declarations

## Why

Current `moonbitlang/core` declares target-specific byte-search functions with `declare fn`. The parser previously produced an `ERROR` node at the `declare` modifier.

## Validation

- `python3 scripts/generate.py`
- `python3 scripts/test.py` (293/293 root corpus tests, 7/7 quotation, 5/5 mbtp)
- `tree-sitter parse --quiet ../core/builtin/bytes_find.mbt`
- `npm run lint`
