### PR TITLE
[codex] support anonymous function effects

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -903,7 +903,9 @@ module.exports = grammar({
         "fn",
         optional("!"),
         $.parameters,
-        optional(seq("->", $.return_type)),
+        // Anonymous functions use the same explicit effect annotations as
+        // named functions, including `raise`, `raise T`, and `noraise`.
+        optional(choice(seq("->", $.return_type), $.error_annotation)),
         $.block_expression
       ),
 

--- a/test/corpus/lambda.txt
+++ b/test/corpus/lambda.txt
@@ -27,6 +27,58 @@ fn init {
             (lowercase_identifier)))))))
 
 ================================================================================
+anonymous function effect annotations
+================================================================================
+fn init {
+  let pure = fn() noraise { () }
+  let fallible = fn() raise { fail("boom") }
+  let async_pure = async fn() -> Int noraise { 42 }
+}
+--------------------------------------------------------------------------------
+
+(structure
+  (function_definition
+    (function_identifier
+      (lowercase_identifier))
+    (block_expression
+      (let_expression
+        (lowercase_identifier)
+        (anonymous_lambda_expression
+          (parameters)
+          (error_annotation)
+          (block_expression
+            (unit_expression))))
+      (let_expression
+        (lowercase_identifier)
+        (anonymous_lambda_expression
+          (parameters)
+          (error_annotation)
+          (block_expression
+            (apply_expression
+              (qualified_identifier
+                (lowercase_identifier))
+              (arguments
+                (argument
+                  (atomic_expression
+                    (literal
+                      (string_literal
+                        (string_fragment
+                          (unescaped_string_fragment)))))))))))
+      (let_expression
+        (lowercase_identifier)
+        (anonymous_lambda_expression
+          (parameters)
+          (return_type
+            (qualified_type_identifier
+              (identifier
+                (uppercase_identifier)))
+            (error_annotation))
+          (block_expression
+            (atomic_expression
+              (literal
+                (integer_literal)))))))))
+
+================================================================================
 one-line
 ================================================================================
 fn init {


### PR DESCRIPTION
## Summary

- parse explicit `raise` and `noraise` annotations after anonymous-function parameters
- reuse the existing `error_annotation` and `return_type` nodes
- cover synchronous, asynchronous, raising, and non-raising forms

## Why

Current `moonbitlang/core` uses `async fn() noraise { ... }` when constructing asynchronous lex buffers. The parser previously produced an `ERROR` node at `noraise`.

## Validation

- `python3 scripts/generate.py`
- `python3 scripts/test.py` (293/293 root corpus tests, 7/7 quotation, 5/5 mbtp)
- `tree-sitter parse --quiet ../core/lexbuf/lexbuf_test.mbt`
- `npm run lint`
