### PR TITLE
[codex] support trait method extensions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -126,6 +126,7 @@ module.exports = grammar({
         $.trait_definition,
         $.impl_definition,
         $.impl_declaration,
+        $.trait_method_extension,
         $.type_alias_definition,
         $.trait_alias_definition,
         $.function_alias_definition
@@ -603,6 +604,24 @@ module.exports = grammar({
         "for",
         $._type
       ),
+
+    // `extend` promotes selected trait methods onto a type without defining
+    // new bodies. Both local types and trait objects use the type-name syntax.
+    trait_method_extension: ($) =>
+      seq(
+        optional($.attributes),
+        optional($.visibility),
+        "extend",
+        field("type", $.type_name),
+        "with",
+        field("trait", $.type_name),
+        "::",
+        "{",
+        list1(",", $.extended_method),
+        "}"
+      ),
+
+    extended_method: ($) => $._lowercase_identifier,
 
     _complex_expression: ($) =>
       choice(

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -172,6 +172,7 @@
 (function_alias_target (lowercase_identifier) @function)
 (trait_method_declaration (function_identifier) @function)
 (impl_definition (function_identifier) @function)
+(trait_method_extension (extended_method) @function.method)
 
 ; Method definitions
 
@@ -225,7 +226,7 @@
 
 [ "package" "import" ] @keyword.import
 
-[ "fn" "test" "impl" "fnalias" ] @keyword.function
+[ "fn" "test" "impl" "fnalias" "extend" ] @keyword.function
 "return" @keyword.return
 [ "while" "loop" "for" "break" "continue" "in" ] @keyword.repeat
 

--- a/test/corpus/extend.txt
+++ b/test/corpus/extend.txt
@@ -1,0 +1,88 @@
+================================================================================
+trait method extensions
+================================================================================
+extend Reader with @io.Reader::{read_some, read_all}
+
+pub extend Deque with Compare::{compare}
+
+extend &Transport with @io.Writer::{write}
+
+#deprecated("Use operators instead", skip_current_package=true)
+#doc(hidden)
+pub extend Deque with Eq::{op_equal, op_not_equal}
+--------------------------------------------------------------------------------
+
+(structure
+  (trait_method_extension
+    (type_name
+      (qualified_type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (type_name
+      (qualified_type_identifier
+        (package_identifier)
+        (dot_identifier
+          (dot_uppercase_identifier))))
+    (extended_method
+      (lowercase_identifier))
+    (extended_method
+      (lowercase_identifier)))
+  (trait_method_extension
+    (visibility)
+    (type_name
+      (qualified_type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (type_name
+      (qualified_type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (extended_method
+      (lowercase_identifier)))
+  (trait_method_extension
+    (type_name
+      (qualified_type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (type_name
+      (qualified_type_identifier
+        (package_identifier)
+        (dot_identifier
+          (dot_uppercase_identifier))))
+    (extended_method
+      (lowercase_identifier)))
+  (trait_method_extension
+    (attributes
+      (attribute
+        (attribute_expression
+          (lowercase_identifier)
+          (attribute_properties
+            (attribute_property
+              (attribute_expression
+                (string_literal
+                  (string_fragment
+                    (unescaped_string_fragment)))))
+            (attribute_property
+              (lowercase_identifier)
+              (attribute_expression
+                (lowercase_identifier))))))
+      (attribute
+        (attribute_expression
+          (lowercase_identifier)
+          (attribute_properties
+            (attribute_property
+              (attribute_expression
+                (lowercase_identifier)))))))
+    (visibility)
+    (type_name
+      (qualified_type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (type_name
+      (qualified_type_identifier
+        (identifier
+          (uppercase_identifier))))
+    (extended_method
+      (lowercase_identifier))
+    (extended_method
+      (lowercase_identifier))))

--- a/test/highlight/extend.mbt
+++ b/test/highlight/extend.mbt
@@ -1,0 +1,5 @@
+///|
+extend Reader with @io.Reader::{read_some, read_all}
+// <- keyword.function
+//                              ^^^^^^^^^ function.method
+//                                         ^^^^^^^^ function.method


### PR DESCRIPTION
## Summary

- parse `extend Type with Trait::{methods}` declarations
- support visibility, attributes, qualified traits, and trait-object targets
- highlight `extend` and promoted method names with direct assertions

## Why

Current `moonbitlang/core` and `moonbitlang/async` explicitly promote selected trait methods with `extend`. The parser previously produced `ERROR` nodes for every such declaration.

## Validation

- `python3 scripts/generate.py`
- `python3 scripts/test.py` (293/293 root corpus tests, 7/7 quotation, 5/5 mbtp)
- `tree-sitter parse --quiet` on the five affected async files
- `test/highlight/extend.mbt` (3 assertions)
- `npm run lint`
